### PR TITLE
feat: implement directory tree parser and printer

### DIFF
--- a/pkg/dir/main.go
+++ b/pkg/dir/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type FileNode struct {
+	Name     string
+	Path     string
+	IsDir    bool
+	Children []*FileNode
+}
+
+func main() {
+	root := "/usr/local"
+	rootNode := parseDirectory(root)
+
+	// Print the directory tree
+	printTree(rootNode, 0)
+}
+
+func parseDirectory(root string) *FileNode {
+	rootNode := &FileNode{Path: root, Name: filepath.Base(root), IsDir: true}
+
+	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		node := &FileNode{Name: info.Name(), Path: path, IsDir: info.IsDir()}
+		parentPath := filepath.Dir(path)
+		parent := findNode(rootNode, parentPath)
+		if parent != nil {
+			parent.Children = append(parent.Children, node)
+		}
+
+		return nil
+	})
+
+	return rootNode
+}
+
+func findNode(node *FileNode, path string) *FileNode {
+	if node.Path == path {
+		return node
+	}
+
+	for _, child := range node.Children {
+		if found := findNode(child, path); found != nil {
+			return found
+		}
+	}
+
+	return nil
+}
+
+func printTree(node *FileNode, level int) {
+	indent := ""
+	for i := 0; i < level; i++ {
+		indent += "  "
+	}
+	fmt.Println(indent, node.Name)
+
+	for _, child := range node.Children {
+		printTree(child, level+1)
+	}
+}


### PR DESCRIPTION
Add functionality to parse a directory structure and print it as a 
tree. Introduce the `FileNode` type to represent files and directories, 
and implement `parseDirectory`, `findNode`, and `printTree` functions 
to build and display the directory hierarchy. This change enables 
visual representation of directory contents for better navigation 
and understanding of file organization.